### PR TITLE
Use a mattermost-operator-sa ServiceAccount.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Current Operator version
-VERSION ?= 0.0.1
+VERSION ?= 0.0.2
 # Default bundle image tag
 BUNDLE_IMG ?= controller-bundle:$(VERSION)
 # Options for 'bundle-build'

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,3 +29,4 @@ spec:
             - "--leader-election-id=mattermost-operator"
           image: controller:latest
       terminationGracePeriodSeconds: 10
+      serviceAccountName: sa

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -8,5 +8,4 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
-  namespace: system
+  name: sa

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+- service_account.yaml
 - role.yaml
 - role_binding.yaml
 - leader_election_role.yaml

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,4 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
-  namespace: system
+  name: sa

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -9,5 +9,4 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
-  namespace: system
+  name: sa

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa


### PR DESCRIPTION
This prevents conflicts with other operators that attempt to assert ownership over the 'default' service account.